### PR TITLE
<chore>:cmd cfg log info->debug

### DIFF
--- a/damocles-manager/dep/sealer_constructor.go
+++ b/damocles-manager/dep/sealer_constructor.go
@@ -88,7 +88,7 @@ func ProvideConfig(gctx GlobalContext, lc fx.Lifecycle, cfgmgr confmgr.ConfigMan
 		return nil, err
 	}
 
-	log.Infof("Sector-manager initial cfg: \n%s\n", buf.String())
+	log.Debugf("Sector-manager initial cfg: \n%s\n", buf.String())
 
 	lc.Append(fx.Hook{
 		OnStart: func(context.Context) error {


### PR DESCRIPTION
damocles-manager 命令总是打印配置信息，影响使用，调低log级别