### PR TITLE
fix(di): inject the `core.SealerCliAPIClient` correctly

### DIFF
--- a/CHANGELOG.zh.md
+++ b/CHANGELOG.zh.md
@@ -4,6 +4,7 @@
 
 
 - damocles-manager
+  - 修复对 core.SealerCliAPIClient 错误的依赖注入，导致 damocles-manager 代理模式无法正常启动 [#1047](https://github.com/ipfs-force-community/damocles/pull/1047)
   - 修复配置多个 Name 为空的 PersistStores 时启动报错的 bug [#1046](https://github.com/ipfs-force-community/damocles/pull/1046)
   - 修复 terminal batch 时缺少对 enable batch 的检查的问题  [#1044](https://github.com/ipfs-force-community/damocles/pull/1044)
   - 修复 snapup 移除旧扇区文件报错 [#1040](https://github.com/ipfs-force-community/damocles/pull/1040)

--- a/damocles-manager/dep/sealer.go
+++ b/damocles-manager/dep/sealer.go
@@ -108,7 +108,9 @@ func Proxy(dest string, opt ProxyOptions) dix.Option {
 	return dix.Options(
 		dix.Override(new(ProxyAddress), ProxyAddress(dest)),
 		dix.Override(new(*core.APIClient), BuildAPIProxyClient),
-		dix.Override(new(*core.SealerCliAPIClient), dix.From(new(*core.APIClient))),
+		dix.Override(new(*core.SealerCliAPIClient), func(a *core.APIClient) *core.SealerCliAPIClient {
+			return &a.SealerCliAPIClient
+		}),
 		dix.If(opt.EnableSectorIndexer,
 			dix.Override(new(core.SectorIndexer), BuildProxiedSectorIndex),
 		),
@@ -137,7 +139,9 @@ func APIClient(target ...interface{}) dix.Option {
 		dix.Override(new(messager.API), BuildMessagerClient),
 		dix.Override(new(market.API), BuildMarketAPI),
 		dix.Override(new(*core.APIClient), MaybeAPIClient),
-		dix.Override(new(*core.SealerCliAPIClient), dix.From(new(*core.APIClient))),
+		dix.Override(new(*core.SealerCliAPIClient), func(a *core.APIClient) *core.SealerCliAPIClient {
+			return &a.SealerCliAPIClient
+		}),
 		dix.If(len(target) > 0, dix.Populate(InvokePopulate, target...)),
 	)
 }


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->


## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->
修复对 core.SealerCliAPIClient 错误的依赖注入，导致 damocles-manager 代理模式无法正常启动

## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 符合 Venus 项目管理规范中关于 PR 的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [x] 具有清晰明确的 [commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [x] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [x] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [x] 通过必要的检查项 / All checks are green
