### PR TITLE
fix: enabling verify_pc2 will automatically abort task. because `pc2_out` is not correctly set to sector state

### DIFF
--- a/CHANGELOG.zh.md
+++ b/CHANGELOG.zh.md
@@ -14,7 +14,7 @@
 
 - damocles-worker
   - 修复无法从统一链服务入口获取 piece 文件 [#1041](https://github.com/ipfs-force-community/damocles/pull/1041)
-  - 支持校验 pc2 的结果 [#1060](https://github.com/ipfs-force-community/damocles/pull/1060)
+  - 支持在 pc2 完成后校验封装的结果 [#1060](https://github.com/ipfs-force-community/damocles/pull/1060)
 
 ## v0.9.0
 

--- a/damocles-worker/src/config.rs
+++ b/damocles-worker/src/config.rs
@@ -63,8 +63,8 @@ pub struct Sealing {
     /// max retry times for request task from sector manager
     pub request_task_max_retries: u32,
 
-    // whether to verify the results of pc2
-    pub verify_pc2: bool,
+    // whether to verify the sealing results alfter pc2
+    pub verify_after_pc2: bool,
 }
 
 impl Default for Sealing {
@@ -82,7 +82,7 @@ impl Default for Sealing {
             rpc_polling_interval: Duration::from_secs(180),
             ignore_proof_check: false,
             request_task_max_retries: 3,
-            verify_pc2: false,
+            verify_after_pc2: false,
         }
     }
 }
@@ -132,8 +132,8 @@ pub struct SealingOptional {
     /// max retry times for request task from sector manager
     pub request_task_max_retries: Option<u32>,
 
-    // whether to verify the results of pc2
-    pub verify_pc2: Option<bool>,
+    // whether to verify the sealing results after pc2
+    pub verify_after_pc2: Option<bool>,
 }
 
 /// configuration for remote store

--- a/damocles-worker/src/sealing/config.rs
+++ b/damocles-worker/src/sealing/config.rs
@@ -160,7 +160,7 @@ pub(crate) fn merge_sealing_fields(
             rpc_polling_interval,
             ignore_proof_check,
             request_task_max_retries,
-            verify_pc2,
+            verify_after_pc2,
         },
     }
 }
@@ -397,7 +397,7 @@ mod tests {
                         rpc_polling_interval: ms(1000),
                         ignore_proof_check: true,
                         request_task_max_retries: 10,
-                        verify_pc2: false,
+                        verify_after_pc2: false,
                     },
                 },
                 SealingThreadInner {
@@ -415,7 +415,7 @@ mod tests {
                         rpc_polling_interval: Some(ms(1000)),
                         ignore_proof_check: None,
                         request_task_max_retries: Some(11),
-                        verify_pc2: Some(true),
+                        verify_after_pc2: Some(true),
                     }),
                 },
                 SealingWithPlan {
@@ -433,7 +433,7 @@ mod tests {
                         rpc_polling_interval: ms(1000),
                         ignore_proof_check: true,
                         request_task_max_retries: 11,
-                        verify_pc2: true,
+                        verify_after_pc2: true,
                     },
                 },
             ),

--- a/damocles-worker/src/sealing/sealing_thread/planner/sealer.rs
+++ b/damocles-worker/src/sealing/sealing_thread/planner/sealer.rs
@@ -267,8 +267,8 @@ impl<'t> Sealer<'t> {
     }
 
     fn handle_pc1_done(&self) -> Result<Event, Failure> {
-        let verify_pc2 = self.task.sealing_ctrl.config().verify_pc2;
-        common::pre_commit2(self.task, verify_pc2).map(|out| {
+        let verify_after_pc2 = self.task.sealing_ctrl.config().verify_after_pc2;
+        common::pre_commit2(self.task, verify_after_pc2).map(|out| {
             if out
                 .registered_proof
                 .feature_enabled(ApiFeature::SyntheticPoRep)

--- a/docs/en/03.damocles-worker-config.md
+++ b/docs/en/03.damocles-worker-config.md
@@ -277,9 +277,9 @@ rpc_client.addr = "/ip4/127.0.0.1/tcp/1789"
 # default is 3
 # request_task_max_retries = 3
 
-# Whether to enable verification of PC2 results
+# whether to verify the sealing results after pc2
 # default is false
-# verify_pc2 = false
+# verify_after_pc2 = false
 ```
 
 The configuration items in `sealing` usually have default items preset from experiences, which removes the need for manual configurations in most cases.

--- a/docs/zh/03.damocles-worker的配置解析.md
+++ b/docs/zh/03.damocles-worker的配置解析.md
@@ -279,9 +279,9 @@ rpc_client.addr = "/ip4/127.0.0.1/tcp/1789"
 # 默认为 3
 # request_task_max_retries = 3
 
-# 是否启用校验 pc2 的结果
+# 是否启用在 pc2 完成后校验封装的结果
 # 默认为 false
-# verify_pc2 = false
+# verify_after_pc2 = false
 ```
 
 `sealing` 中的配置项通常有根据经验预设的默认项，这使得我们在绝大多数情况下无需自行配置。


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->


## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->


## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 符合 Venus 项目管理规范中关于 PR 的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [x] 具有清晰明确的 [commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [x] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [x] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [x] 通过必要的检查项 / All checks are green
